### PR TITLE
Add custom backend support and cross-platform PlatformIO upload

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -68,6 +68,8 @@ A detailled build guide can be found on [YouTube](https://www.youtube.com/watch?
 
 Simply power up your BierBot Brick-32 and use any WiFi enabled device (Android, iPhone, Tablet, Mac, or PC) to scan for a Brick-32-Wifi (i.e. `Brick-32-0042123`) to configure your Brick. You'll need an API key which you can get for free at [bricks.bierbot.com](https://bricks.bierbot.com).
 
+The configuration portal uses BierBot Bricks as its backend by default. Select `Custom` to use another backend and enter its complete API endpoint, for example `https://example.com/api/iot/v1`. Both HTTP and HTTPS endpoints are supported.
+
 ### Buttons and LEDs
 
 The following Buttons are available

--- a/docs/DEV.MD
+++ b/docs/DEV.MD
@@ -13,6 +13,38 @@ Flashing must not only include the programm itself, but the bootloader, the part
 "/home/bernhard/.platformio/penv/bin/python" "/home/bernhard/.platformio/packages/tool-esptoolpy/esptool.py" --chip esp32 --port "/dev/ttyUSB0" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB 0x1000 /home/bernhard/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/bin/bootloader_dio_40m.bin 0x8000 /home/bernhard/Desktop/wd/BierBot-Brick-ESP32/.pio/build/az-delivery-devkit-v4/partitions.bin 0xe000 /home/bernhard/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/az-delivery-devkit-v4/firmware.bin
 ```
 
+## Upload with PlatformIO
+
+Instead of collecting the four binaries by hand, PlatformIO resolves all tool
+and framework paths itself and writes bootloader, partition table, boot app and
+firmware in one go - with the same flash settings the Flash Download Tool uses
+(DIO, 40 MHz, 4 MB, 460800 baud). `platformio.ini` contains no OS specific
+paths, so this works identically on Windows, Linux and macOS.
+
+Put the Sonoff into download mode first:
+
+1. Unplug the USB cable of the USB-to-serial adapter.
+1. Press and hold the button on the Sonoff.
+1. Plug the USB cable back in while still holding the button.
+1. Release the button.
+1. Upload the matching environment:
+
+```
+pio run -e sonoff_th_origin -t upload
+pio run -e sonoff_th_elite -t upload
+```
+
+The serial port is detected automatically. Only if several serial adapters are
+connected, pass it explicitly (`pio device list` prints the available ports):
+
+```
+pio run -e sonoff_th_origin -t upload --upload-port COM5                    # Windows
+pio run -e sonoff_th_origin -t upload --upload-port /dev/ttyUSB0            # Linux
+pio run -e sonoff_th_origin -t upload --upload-port /dev/cu.usbserial-0001  # macOS
+```
+
+Afterwards `pio device monitor -e sonoff_th_origin` shows the serial log.
+
 To make a new image:
 
 1. Run "sonoff_th_origin" > "build"

--- a/docs/FLASH.MD
+++ b/docs/FLASH.MD
@@ -20,6 +20,13 @@ and TX are crossed):
 | `TX0`  | `RXD`                 |
 | `RX0`  | `TXD`                 |
 
+Make sure the `3V3` dupont connector really sits tight on the header pin. A
+loose contact still powers the chip well enough to connect, but the current
+drawn while erasing and writing the flash makes the voltage drop, the ESP32
+reboots and the upload aborts in the middle - see the troubleshooting section
+below. If in doubt, pull the connector off, turn it by 90 degrees and push it
+back on.
+
 Then:
 
 1. Unplug the USB cable of the USB-to-serial adapter.
@@ -45,7 +52,15 @@ pio run -e sonoff_th_origin -t upload --upload-port /dev/cu.usbserial-0001  # ma
 A successful run ends with `Hash of data verified.` and `Hard resetting via RTS
 pin...`. Use `pio device monitor -e sonoff_th_origin` to watch the serial log.
 
-If the upload fails with `Wrong boot mode detected (0x13)` or `No serial data
-received`, the Sonoff is not in download mode - repeat the four steps above.
-Note that opening the serial port resets the chip, so put it into download mode
-directly before the upload and do not run a serial monitor in between.
+## Troubleshooting
+
+`Wrong boot mode detected (0x13)` or `No serial data received` while connecting:
+the Sonoff is not in download mode - repeat the four steps above. Note that
+opening the serial port resets the chip, so put it into download mode directly
+before the upload and do not run a serial monitor in between.
+
+`The chip stopped responding` or `Invalid head of packet (0x65)` in the middle
+of writing the firmware: the ESP32 rebooted during the upload because its supply
+voltage broke down. Check the `3V3` and `GND` connections first, they are the
+usual cause. Lowering `upload_speed` to `115200` in `platformio.ini` does not
+help against this - a bad contact stays a bad contact.

--- a/docs/FLASH.MD
+++ b/docs/FLASH.MD
@@ -1,3 +1,51 @@
 # How to flash
 
 If you read this, instructions from the YouTube video are still the easiest way to go.
+
+## Flashing a self-built firmware with PlatformIO
+
+If you build the firmware yourself, you do not need the Flash Download Tool at
+all. PlatformIO writes the bootloader, the partition table, the boot app and the
+firmware in one step, using the same flash settings (DIO, 40 MHz, 4 MB, 460800
+baud). The configuration in `platformio.ini` is free of OS specific paths and
+works the same on Windows, Linux and macOS.
+
+Wire the USB-to-serial adapter to the serial header of the Sonoff (note that RX
+and TX are crossed):
+
+| Sonoff | USB-to-serial adapter |
+| ------ | --------------------- |
+| `GND`  | `GND`                 |
+| `3V3`  | `3V3`                 |
+| `TX0`  | `RXD`                 |
+| `RX0`  | `TXD`                 |
+
+Then:
+
+1. Unplug the USB cable of the USB-to-serial adapter.
+1. Press and hold the button on the Sonoff.
+1. Plug the USB cable back in while still holding the button.
+1. Release the button - the Sonoff now waits for the download.
+1. Run the upload for your device:
+
+```
+pio run -e sonoff_th_origin -t upload
+pio run -e sonoff_th_elite -t upload
+```
+
+The serial port is detected automatically. If several serial adapters are
+connected, list them with `pio device list` and pass the right one:
+
+```
+pio run -e sonoff_th_origin -t upload --upload-port COM5                    # Windows
+pio run -e sonoff_th_origin -t upload --upload-port /dev/ttyUSB0            # Linux
+pio run -e sonoff_th_origin -t upload --upload-port /dev/cu.usbserial-0001  # macOS
+```
+
+A successful run ends with `Hash of data verified.` and `Hard resetting via RTS
+pin...`. Use `pio device monitor -e sonoff_th_origin` to watch the serial log.
+
+If the upload fails with `Wrong boot mode detected (0x13)` or `No serial data
+received`, the Sonoff is not in download mode - repeat the four steps above.
+Note that opening the serial port resets the chip, so put it into download mode
+directly before the upload and do not run a serial monitor in between.

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,16 +7,55 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
+;
+; This configuration is intentionally free of any OS specific paths, so it
+; works identically on Windows, Linux and macOS. The serial port is detected
+; automatically; override it only if needed, see "Upload" below.
+;
+; Put the Sonoff into download mode before every upload:
+;   1. unplug the USB cable of the USB-to-serial adapter
+;   2. press and hold the button on the Sonoff
+;   3. plug the USB cable back in while still holding the button
+;   4. release the button - the Sonoff now waits for the download
+;   5. start the upload:
+;
+;   pio run -e sonoff_th_origin -t upload
+;   pio run -e sonoff_th_elite  -t upload
+;
+; Explicit port (only required if several serial adapters are connected):
+;
+;   Windows:      pio run -e sonoff_th_origin -t upload --upload-port COM5
+;   Linux:        pio run -e sonoff_th_origin -t upload --upload-port /dev/ttyUSB0
+;   macOS:        pio run -e sonoff_th_origin -t upload --upload-port /dev/cu.usbserial-0001
+;
+; "pio device list" prints the available ports on every platform.
 
 [env]
-platform = espressif32
+; Pinned so that all platforms build with the same toolchain and Arduino core.
+platform = espressif32@7.0.1
 board = az-delivery-devkit-v4
 framework = arduino
 board_build.mcu = esp32
 board_build.f_cpu = 240000000L
+
 upload_protocol = esptool
+upload_speed = 460800
+; Same flash settings the "Flash Download Tool" uses for the release images.
+board_build.flash_mode = dio
+board_build.f_flash = 40000000L
+board_upload.flash_size = 4MB
+; Do not reset the chip before flashing: the Sonoff header does not expose
+; GPIO0, so a reset would leave the manually selected download mode and boot
+; the firmware instead ("Invalid head of packet" / "Wrong boot mode detected").
+board_upload.before_reset = no_reset
+board_upload.after_reset = hard_reset
+
 monitor_speed = 115200
-lib_deps = 
+monitor_filters =
+	time
+	esp32_exception_decoder
+
+lib_deps =
 	lennarthennigs/Button2@^2.0.3
 	paulstoffregen/OneWire@^2.3.7
 	milesburton/DallasTemperature@^3.10.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,12 @@ enum MAIN_STATE
 };
 
 #define EEPROM_ADDRESS_APIKEY 0
+#define APIKEY_MAX_LENGTH 20
+#define EEPROM_ADDRESS_BACKEND_URL 32
+#define BACKEND_URL_MAX_LENGTH 180
 #define HTTP_REQUEST_RESPONSE_BUF_LEN 512
+
+const char *DEFAULT_BACKEND_URL = "https://bricks.bierbot.com/api/iot/v1";
 
 Button2 btn_main;
 
@@ -90,6 +95,8 @@ auto drsw = GenericOut(0, false); // Init with 0 -> "not present"
 String apikey;
 WiFiManager wm;                           // global wm instance
 WiFiManagerParameter custom_field_apikey; // global param ( for non blocking w params )
+WiFiManagerParameter custom_field_backend;
+String backend_config_html;
 HTTPClient http;                          // Declare an object of class HTTPClient
 WiFiClientSecure https;
 
@@ -140,9 +147,14 @@ void writeStringToEEPROM(int addrOffset, const String &strToWrite)
   Serial.println("EEPROM committed.");
 }
 
-String readStringFromEEPROM(int addrOffset)
+String readStringFromEEPROM(int addrOffset, int maxLength)
 {
   int newStrLen = EEPROM.read(addrOffset);
+  if (newStrLen <= 0 || newStrLen > maxLength || addrOffset + newStrLen >= 512)
+  {
+    return "";
+  }
+
   char data[newStrLen + 1];
   for (int i = 0; i < newStrLen; i++)
   {
@@ -152,9 +164,80 @@ String readStringFromEEPROM(int addrOffset)
   return String(data);
 }
 
+String escapeHtmlAttribute(String value)
+{
+  value.replace("&", "&amp;");
+  value.replace("\"", "&quot;");
+  value.replace("'", "&#39;");
+  value.replace("<", "&lt;");
+  value.replace(">", "&gt;");
+  return value;
+}
+
+bool isValidBackendUrl(const String &url)
+{
+  return url.startsWith("http://") || url.startsWith("https://");
+}
+
+String getConfiguredBackendUrl()
+{
+  String configured_url = readStringFromEEPROM(
+    EEPROM_ADDRESS_BACKEND_URL,
+    BACKEND_URL_MAX_LENGTH
+  );
+  configured_url.trim();
+  return isValidBackendUrl(configured_url)
+    ? configured_url
+    : String(DEFAULT_BACKEND_URL);
+}
+
+String createBackendConfigHtml(const String &configured_url)
+{
+  bool custom_backend = isValidBackendUrl(configured_url);
+  String html =
+    "<label for='backend_mode'>Backend</label>"
+    "<select id='backend_mode' name='backend_mode' onchange='toggleBackendUrl()'>"
+    "<option value='bierbot'";
+  if (!custom_backend)
+  {
+    html += " selected";
+  }
+  html += ">BierBot Bricks</option><option value='custom'";
+  if (custom_backend)
+  {
+    html += " selected";
+  }
+  html +=
+    ">Custom</option></select>"
+    "<div id='backend_url_wrap' style='display:";
+  html += custom_backend ? "block" : "none";
+  html +=
+    "'><label for='backend_url'>Custom Backend URL</label>"
+    "<input id='backend_url' name='backend_url' type='url' maxlength='";
+  html += String(BACKEND_URL_MAX_LENGTH);
+  html +=
+    "' placeholder='https://example.com/api/iot/v1' value='";
+  html += escapeHtmlAttribute(configured_url);
+  html +=
+    "'></div>"
+    "<script>"
+    "function toggleBackendUrl(){"
+    "var custom=document.getElementById('backend_mode').value==='custom';"
+    "var wrap=document.getElementById('backend_url_wrap');"
+    "var input=document.getElementById('backend_url');"
+    "wrap.style.display=custom?'block':'none';"
+    "input.required=custom;"
+    "}"
+    "document.addEventListener('DOMContentLoaded',toggleBackendUrl);"
+    "</script>";
+  return html;
+}
+
 void resetConfig()
 {
   Serial.println("Erasing Config, restarting");
+  writeStringToEEPROM(EEPROM_ADDRESS_APIKEY, "");
+  writeStringToEEPROM(EEPROM_ADDRESS_BACKEND_URL, "");
   wm.resetSettings();
   ESP.restart();
 }
@@ -339,12 +422,24 @@ String getParam(String name)
 void saveParamCallback()
 {
   Serial.println("[CALLBACK] saveParamCallback fired");
-  apikey = getParam("apikey").substring(0, 20);
-  Serial.println("PARAM apikey straight = " + apikey);
-  // String apikey = getParam("apikey");
+  apikey = getParam("apikey").substring(0, APIKEY_MAX_LENGTH);
   writeStringToEEPROM(EEPROM_ADDRESS_APIKEY, apikey);
-  String apikey_restored = readStringFromEEPROM(EEPROM_ADDRESS_APIKEY);
-  Serial.println("PARAM apikey from EEPROM = " + apikey_restored);
+
+  String backend_url = getParam("backend_url").substring(
+    0,
+    BACKEND_URL_MAX_LENGTH
+  );
+  backend_url.trim();
+  if (getParam("backend_mode") != "custom" || !isValidBackendUrl(backend_url))
+  {
+    backend_url = "";
+  }
+  writeStringToEEPROM(EEPROM_ADDRESS_BACKEND_URL, backend_url);
+
+  Serial.println(
+    "Backend configured: " +
+    (backend_url.length() > 0 ? backend_url : String(DEFAULT_BACKEND_URL))
+  );
 }
 
 String getFlashChipId()
@@ -460,8 +555,25 @@ void setup()
   // wifi manager
   Serial.println("initializing WiFi..");
   led_wifi.Blink(200,200).Forever();
-  new (&custom_field_apikey) WiFiManagerParameter("apikey", "Bricks API Key", "", 37, "placeholder=\"get your API key at bricks.bierbot.com\"");
+  String stored_apikey = readStringFromEEPROM(
+    EEPROM_ADDRESS_APIKEY,
+    APIKEY_MAX_LENGTH
+  );
+  String stored_backend_url = readStringFromEEPROM(
+    EEPROM_ADDRESS_BACKEND_URL,
+    BACKEND_URL_MAX_LENGTH
+  );
+  new (&custom_field_apikey) WiFiManagerParameter(
+    "apikey",
+    "Bricks API Key",
+    stored_apikey.c_str(),
+    37,
+    "placeholder=\"get your API key at bricks.bierbot.com\""
+  );
   wm.addParameter(&custom_field_apikey);
+  backend_config_html = createBackendConfigHtml(stored_backend_url);
+  new (&custom_field_backend) WiFiManagerParameter(backend_config_html.c_str());
+  wm.addParameter(&custom_field_backend);
   // wm.setConfigPortalBlocking(false);
   wm.setSaveConfigCallback(saveParamCallback);
   bool res;
@@ -547,11 +659,16 @@ void contactBackend()
 {
   if (1 == 1)
   { // WiFi.status() == WL_CONNECTED) { //Check WiFi connection status
-    String apikey = readStringFromEEPROM(EEPROM_ADDRESS_APIKEY);
+    String apikey = readStringFromEEPROM(
+      EEPROM_ADDRESS_APIKEY,
+      APIKEY_MAX_LENGTH
+    );
     String s_number_temp_0 = String(celsius);
     String a_bool_epower_0 = String((int)ac1.getCurrentValue());
     String a_bool_epower_1 = String((int)drsw.getCurrentValue());
-    String url ="https://bricks.bierbot.com/api/iot/v1?apikey=" + apikey + "&brand=" + "bierbot" + "&version=" + global_version + "&s_number_temp_0=" + s_number_temp_0 + "&chipid=" + chipid + "&s_number_temp_id_0=" + sensor_id;
+    String url = getConfiguredBackendUrl();
+    url += url.indexOf('?') >= 0 ? "&" : "?";
+    url += "apikey=" + apikey + "&brand=" + "bierbot" + "&version=" + global_version + "&s_number_temp_0=" + s_number_temp_0 + "&chipid=" + chipid + "&s_number_temp_id_0=" + sensor_id;
     if (drsw.isValid()) { // TH Elite series
       url += "&type=sonoff_th_elite&a_bool_epower_0=" + a_bool_epower_0 + "&a_bool_epower_1=" + a_bool_epower_1;
     }
@@ -563,13 +680,17 @@ void contactBackend()
     Serial.print(", a_bool_epower_0=" + a_bool_epower_0);
     Serial.println(", a_bool_epower_1=" + a_bool_epower_1);
 
-    WiFiClientSecure client;
-    client.setInsecure(); // unfortunately necessary, ESP8266 does not support SSL without hard coding certificates
-    char cchar_url[url.length() + 1];
-    url.toCharArray(cchar_url, url.length() + 1); // Converts String into character array
-    client.connect(cchar_url, 443);
-
-    http.begin(client, url);
+    WiFiClient client;
+    WiFiClientSecure secure_client;
+    if (url.startsWith("https://"))
+    {
+      secure_client.setInsecure(); // certificates cannot be hard coded for custom backends
+      http.begin(secure_client, url);
+    }
+    else
+    {
+      http.begin(client, url);
+    }
 
     Serial.println("submitting GET to " + url);
     int httpCode = http.GET(); // GET has issues with 301 forwards


### PR DESCRIPTION
This PR adds two independent improvements. Happy to split them into
separate PRs if you prefer.

## Configurable backend

The backend URL was hardcoded to `https://bricks.bierbot.com/api/iot/v1`.
The config portal now offers a "Backend" dropdown: `BierBot Bricks`
(default, unchanged behaviour) or `Custom` with a free-text URL field.
The URL is stored in EEPROM at offset 32 and only accepted if it starts
with `http://` or `https://`, otherwise the default is used.

Related changes needed to make this work:
- `readStringFromEEPROM()` now takes a max length and returns an empty
  string for uninitialized/garbage length bytes instead of reading past
  the buffer.
- HTTP is used for `http://` endpoints, HTTPS (insecure, as before) for
  `https://` ones. The dead `client.connect(url, 443)` call was removed.
- Query parameters are appended with `&` if the configured URL already
  contains a `?`.
- The config portal now pre-fills the stored API key instead of showing
  an empty field.
- `resetConfig()` clears both EEPROM entries.
- Values rendered into the portal HTML are escaped.

## Cross-platform upload via PlatformIO

`platformio.ini` now carries the same flash settings the Flash Download
Tool uses for the release images (DIO, 40 MHz, 4 MB, 460800 baud), so
`pio run -e sonoff_th_origin -t upload` writes bootloader, partition
table, boot app and firmware in one step - no manual collecting of the
four binaries. No OS specific paths are involved, so this works the same
on Windows, Linux and macOS. `platform` is pinned to `espressif32@7.0.1`.

`board_upload.before_reset = no_reset` is required because the Sonoff
header does not expose GPIO0: a reset before flashing would leave the
manually selected download mode.

`docs/FLASH.MD` and `docs/DEV.MD` document the wiring, the download mode
procedure and the two failure modes I ran into (wrong boot mode, and
aborted uploads caused by a loose 3V3 contact).
